### PR TITLE
detect editor when opening a portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cpcache
 .nrepl-port
 target
+.portal

--- a/src/scicloj/kind_portal/v1/session.clj
+++ b/src/scicloj/kind_portal/v1/session.clj
@@ -17,14 +17,9 @@
            {:launcher :intellij})
       {}))
 
-(defn open
+(defn open-if-needed
   "Like portal/open, but stores the result in *portal-session.
   If there is already a session, it makes sure that it is open,
   Otherwise opens a new inspector window."
-  [config]
-  (swap! *portal-session portal/open config))
-
-(defn open-if-needed
-  "Ensures we have an open session"
-  []
-  (open (detect-editor)))
+  ([] (open-if-needed (detect-editor)))
+  ([config] (swap! *portal-session portal/open config)))

--- a/src/scicloj/kind_portal/v1/session.clj
+++ b/src/scicloj/kind_portal/v1/session.clj
@@ -1,9 +1,30 @@
 (ns scicloj.kind-portal.v1.session
-  (:require [portal.api :as portal]))
+  (:require [clojure.java.io :as io]
+            [portal.api :as portal]))
 
 (def *portal-session (atom nil))
 
-(defn open-if-needed []
-  (if-let [p @*portal-session]
-    (portal/open p)
-    (reset! *portal-session (portal/open))))
+(defn detect-editor
+  "When you run the portal plugin in an IDE, it creates a config file in `.portal/editor.edn`
+  See https://cljdoc.org/d/djblue/portal/0.46.0/doc/editors for more information.
+  If we detect the file you don't need to set the configuration manually."
+  []
+  (or (and (.exists (io/file ".portal" "emacs.edn"))
+           {:launcher :emacs})
+      (and (.exists (io/file ".portal" "vs-code.edn"))
+           {:launcher :vs-code})
+      (and (.exists (io/file ".portal" "intellij.edn"))
+           {:launcher :intellij})
+      {}))
+
+(defn open
+  "Like portal/open, but stores the result in *portal-session.
+  If there is already a session, it makes sure that it is open,
+  Otherwise opens a new inspector window."
+  [config]
+  (swap! *portal-session portal/open config))
+
+(defn open-if-needed
+  "Ensures we have an open session"
+  []
+  (open (detect-editor)))


### PR DESCRIPTION
checks the .portal folder for files created by editors when launching portal plugins.