### PR TITLE
avoid using new `update-vals` core fn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
            :build {:deps {io.github.seancorfield/build-clj
                           {:git/tag "v0.6.4" :git/sha "c21cfde"}}
                    :ns-default build}
+           ;; Run tests with `clojure -M:test -m cognitect.test-runner`
            :test {:extra-paths ["test"]
                   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
                                io.github.cognitect-labs/test-runner

--- a/src/scicloj/kind_portal/v1/impl.clj
+++ b/src/scicloj/kind_portal/v1/impl.clj
@@ -148,6 +148,6 @@
 (add-preparer!
  :kind/map
  (fn [m]
-   (-> m
-       (update-keys prepare-value)
-       (update-vals prepare-value))))
+   (into (empty m)
+         (for [[k v] m]
+           [(prepare-value k) (prepare-value v)]))))

--- a/test/scicloj/kind_portal/v1/api_test.clj
+++ b/test/scicloj/kind_portal/v1/api_test.clj
@@ -1,9 +1,14 @@
 (ns scicloj.kind-portal.v1.api_test
-  (:require  [scicloj.kind-portal.v1.api :as kind-portal]
-             [scicloj.kindly.v4.kind :as kind]
-             [scicloj.kindly-advice.v1.api :as kindly-advice]
-             [tablecloth.api :as tc]))
+  (:require [clojure.test :refer [deftest testing is]]
+            [scicloj.kind-portal.v1.api :as kind-portal]
+            [scicloj.kindly.v4.kind :as kind]))
 
-(kind-portal/kindly-submit-context
- {:form '(kind/hiccup
-          [:h1 "a"])})
+(deftest submit-context-test
+  (kind-portal/kindly-submit-context
+    {:form `(kind/hiccup [:h1 "a"])}))
+
+(deftest preparation-test
+  (is (= "^#:kindly{:kind :kind/map} {^{:kindly/kind :kind/hiccup, :portal.viewer/default :portal.viewer/hiccup} [:div \"A\"] ^{:kindly/kind :kind/hiccup, :portal.viewer/default :portal.viewer/hiccup} [:div \"B\"], ^#:portal.viewer{:default :portal.viewer/hiccup} [:div nil [:portal.viewer/inspector :c]] {^#:portal.viewer{:default :portal.viewer/hiccup} [:div nil [:portal.viewer/inspector :d]] ^{:kindly/kind :kind/hiccup, :portal.viewer/default :portal.viewer/hiccup} [:div \"E\"]}}"
+         (binding [*print-meta* true]
+           (pr-str (kind-portal/prepare {:value (kind/map {(kind/hiccup [:div "A"]) (kind/hiccup [:div "B"])
+                                                           :c                       {:d (kind/hiccup [:div "E"])}})}))))))


### PR DESCRIPTION
As a library, we shouldn't force users to use a new Clojure version. Seeing it is easy to avoid using `update-vals`, just use another approach.